### PR TITLE
17 color configuration should happen in nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "base16-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689473676,
+        "narHash": "sha256-L0RhUr9+W5EPWBpLcmkKpUeCEWRs/kLzVMF3Vao2ZU0=",
+        "owner": "tinted-theming",
+        "repo": "base16-schemes",
+        "rev": "d95123ca6377cd849cfdce92c0a24406b0c6a789",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-schemes",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -89,6 +105,25 @@
         "type": "github"
       }
     },
+    "nix-colors": {
+      "inputs": {
+        "base16-schemes": "base16-schemes",
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1695388192,
+        "narHash": "sha256-2jelpE7xK+4M7jZNyWL7QYOYegQLYBDQS5bvdo8XRUQ=",
+        "owner": "Misterio77",
+        "repo": "nix-colors",
+        "rev": "37227f274b34a3b51649166deb94ce7fec2c6a4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Misterio77",
+        "repo": "nix-colors",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1697059129,
@@ -105,11 +140,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1694911725,
+        "narHash": "sha256-8YqI+YU1DGclEjHsnrrGfqsQg3Wyga1DfTbJrN3Ud0c=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "819180647f428a3826bfc917a54449da1e532ce0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "neovim": "neovim",
+        "nix-colors": "nix-colors",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,11 @@
     # Neovim
     neovim.url = "github:Martin-Lndbl/nix-neovim-module";
     neovim.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-colors.url = "github:Misterio77/nix-colors";
   };
 
-  outputs = { self, nixpkgs, home-manager, hyprland, neovim, ... }@inputs:
+  outputs = { self, nixpkgs, home-manager, hyprland, neovim, nix-colors, ... }@inputs:
     let
       inherit (self) outputs;
       forAllSystems = nixpkgs.lib.genAttrs [
@@ -88,6 +90,7 @@
           modules = [
             hyprland.homeManagerModules.default
             neovim.homeManagerModules.default
+            nix-colors.homeManagerModules.default
             ./home-manager/home.nix
             ./home-manager/hyprland
             {

--- a/home-manager/colorschemes/spacecamp.nix
+++ b/home-manager/colorschemes/spacecamp.nix
@@ -1,0 +1,23 @@
+{
+  slug = "spacecamp";
+  name = "SpaceCamp";
+  author = "https://github.com/jaredgorski/SpaceCamp";
+  colors = {
+    base00 = "#282828";
+    base01 = "#D71A1A";
+    base02 = "#57BA37";
+    base03 = "#F0D50C";
+    base04 = "#91AADF";
+    base05 = "#CF73E6";
+    base06 = "#B7CBF4";
+    base07 = "#DEDEDE";
+    base08 = "#666666";
+    base09 = "#FF0000";
+    base0A = "#D8FA3B";
+    base0B = "#E7C547";
+    base0C = "#B7CBF4";
+    base0D = "#B77EE0";
+    base0E = "#A9C1DE";
+    base0F = "#EEEEEE";
+  };
+}

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -6,6 +6,8 @@
   home.username = "mrtn";
   home.homeDirectory = "/home/mrtn";
 
+  colorScheme = inputs.nix-colors.colorSchemes.dracula;
+
   nixpkgs = {
     overlays = outputs.overlays.modifications ;
     config = {

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -6,7 +6,7 @@
   home.username = "mrtn";
   home.homeDirectory = "/home/mrtn";
 
-  colorScheme = inputs.nix-colors.colorSchemes.dracula;
+  colorScheme = import ./colorschemes/spacecamp.nix;
 
   nixpkgs = {
     overlays = outputs.overlays.modifications ;

--- a/home-manager/hyprland/swaylock.nix
+++ b/home-manager/hyprland/swaylock.nix
@@ -9,9 +9,9 @@
         indicator-idle-visible = false;
         indicator-radius = 60;
         show-failed-attemps = true;
-        inside-color = "ffffff00";
-        key-hl-color = "153B3099";
-        ring-color = "3B3B3999";
+        inside-color = config.colorScheme.colors.base00;
+        key-hl-color = config.colorScheme.colors.base08;
+        ring-color = config.colorScheme.colors.base07;
       };
     };
 }

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -6,13 +6,11 @@
     ./firefox.nix
     ./git.nix
     ./ssh.nix
+    ./neovim.nix
     # ./vscode.nix
   ];
   programs = {
     home-manager.enable = true;
-
-    neovim.baseConfiguration.enable = true;
-    neovim.baseConfiguration.colorscheme = "spacecamp_transparent";
 
     direnv.enable = true;
   };

--- a/home-manager/programs/neovim.nix
+++ b/home-manager/programs/neovim.nix
@@ -1,0 +1,50 @@
+{ pkgs, config, ... }:
+
+let
+  spacecamp = pkgs.vimUtils.buildVimPlugin rec {
+    pname = "spacecamp";
+    version = "efe16a90234ae4c7714412d16f36af34284af321";
+    src = pkgs.fetchFromGitHub {
+      owner = "Martin-Lndbl";
+      repo = pname;
+      rev = version;
+      sha256 = "sha256-I/oeZ+07KjMR8rqGk2+D7XeINk8bOP0quOSsuoatMLY=";
+    };
+  };
+
+  base16_build = {
+    plugin = pkgs.vimPlugins.nvim-base16;
+    type = "lua";
+    config = with config.colorscheme.colors; "
+          require('base16-colorscheme').setup({
+            base00 = '#${base00}',
+            base01 = '#${base01}',
+            base02 = '#${base02}',
+            base03 = '#${base03}',
+            base04 = '#${base04}',
+            base05 = '#${base05}',
+            base06 = '#${base06}',
+            base07 = '#${base07}',
+            base08 = '#${base08}',
+            base09 = '#${base09}',
+            base0A = '#${base0A}',
+            base0B = '#${base0B}',
+            base0C = '#${base0C}',
+            base0D = '#${base0D}',
+            base0E = '#${base0E}',
+            base0F = '#${base0F}',
+          })";
+  };
+
+in
+
+{
+  programs.neovim = {
+    baseConfiguration.enable = true;
+    baseConfiguration.colorscheme = "spacecamp_transparent";
+    plugins = [
+      spacecamp
+      # base16_build
+    ];
+  };
+}


### PR DESCRIPTION
# Phase 1

## New

* added [nix-colors](https://github.com/Misterio77/nix-colors) as flake input and defined colorscheme.
* copied [spacecamp](https://github.com/jaredgorski/SpaceCamp) and adjusted the syntax.

## Modified

[NeoVim]
* using nvim-base16 plugin to create a nvim-colorscheme out of base16 colors from nix-colors.
* integration to [nix-neovim-module](https://github.com/Martin-Lndbl/nix-neovim-module) completed

[SwayLock]
* colors integrated in swaylock

## TODO
* integration into terminal
* integration into bash?