### PR TITLE
17 color configuration should happen in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
             ./home-manager/home.nix
             ./home-manager/hyprland
             {
-              config.appearance.wallpaper = "~/downloads/wallpaper/polaris.jpg";
+              config.appearance.wallpaper = "~/downloads/wallpaper/jp2.png";
               config.appearance.lockScreen = "~/downloads/wallpaper/nix.png";
               config.appearance.fontSize = 14;
               config.monitors.center = "eDP-1";

--- a/home-manager/colorschemes/spacecamp.nix
+++ b/home-manager/colorschemes/spacecamp.nix
@@ -3,21 +3,21 @@
   name = "SpaceCamp";
   author = "https://github.com/jaredgorski/SpaceCamp";
   colors = {
-    base00 = "#282828";
-    base01 = "#D71A1A";
-    base02 = "#57BA37";
-    base03 = "#F0D50C";
-    base04 = "#91AADF";
-    base05 = "#CF73E6";
-    base06 = "#B7CBF4";
-    base07 = "#DEDEDE";
-    base08 = "#666666";
-    base09 = "#FF0000";
+    base00 = "#121212";
+    base01 = "#262626";
+    base02 = "#49483E";
+    base03 = "#6B6B6B";
+    base04 = "#B0B0B0";
+    base05 = "#F0D50C";
+    base06 = "#DEDEDE";
+    base07 = "#EEEEEE";
+    base08 = "#FF0000";
+    base09 = "#F66100";
     base0A = "#D8FA3B";
-    base0B = "#E7C547";
+    base0B = "#57BA37";
     base0C = "#B7CBF4";
-    base0D = "#B77EE0";
-    base0E = "#A9C1DE";
-    base0F = "#EEEEEE";
+    base0D = "#91AADF";
+    base0E = "#B77EE0";
+    base0F = "#CF73E6";
   };
 }

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -6,6 +6,7 @@
   home.username = "mrtn";
   home.homeDirectory = "/home/mrtn";
 
+  # colorScheme = inputs.nix-colors.colorSchemes.dracula;
   colorScheme = import ./colorschemes/spacecamp.nix;
 
   nixpkgs = {

--- a/home-manager/hyprland/swaylock.nix
+++ b/home-manager/hyprland/swaylock.nix
@@ -10,8 +10,8 @@
         indicator-radius = 60;
         show-failed-attemps = true;
         inside-color = config.colorScheme.colors.base00;
-        key-hl-color = config.colorScheme.colors.base08;
-        ring-color = config.colorScheme.colors.base07;
+        key-hl-color = config.colorScheme.colors.base05;
+        ring-color = config.colorScheme.colors.base02;
       };
     };
 }

--- a/home-manager/programs/alacritty.nix
+++ b/home-manager/programs/alacritty.nix
@@ -38,8 +38,8 @@
         };
         colors = {
           primary = {
-            background = "#1d1f21";
-            foreground = "#c5c8c5";
+            background = "#${config.colorscheme.colors.base00}";
+            foreground = "#${config.colorscheme.colors.base07}";
           };
         };
       };

--- a/home-manager/programs/neovim.nix
+++ b/home-manager/programs/neovim.nix
@@ -17,7 +17,7 @@ let
     type = "lua";
     config = with config.colorscheme.colors; "
           require('base16-colorscheme').setup({
-            base00 = '#${base00}',
+            base00 = 'NONE',
             base01 = '#${base01}',
             base02 = '#${base02}',
             base03 = '#${base03}',
@@ -41,10 +41,8 @@ in
 {
   programs.neovim = {
     baseConfiguration.enable = true;
-    baseConfiguration.colorscheme = "spacecamp_transparent";
     plugins = [
-      spacecamp
-      # base16_build
+      base16_build
     ];
   };
 }


### PR DESCRIPTION
# Changes:
- Fixed base16 arrangement of SpaceCamp colorscheme
- Changed swaylock colors
- Fixed transparent background for nvim-base16 build
- integrated alacritty to nix-colors configuration